### PR TITLE
Added observation_name attribute to CommentType in MAEC Package

### DIFF
--- a/maec_package_schema.xsd
+++ b/maec_package_schema.xsd
@@ -129,6 +129,11 @@
 						<xs:documentation>The timestamp field specifies the date/time that the comment was added.</xs:documentation>
 					</xs:annotation>
 				</xs:attribute>
+				<xs:attribute name="observation_name" type="xs:string">
+					<xs:annotation>
+						<xs:documentation>The observation_name field captures the name, type, or identifier of an observation, for comments that refer to the observation of particular entities. For example, a comment that refers to a command and control (C2) encryption key could have an observation_name of "C2 Encryption Key".</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
 			</xs:extension>
 		</xs:simpleContent>
 	</xs:complexType>


### PR DESCRIPTION
Added observation_name attribute to the CommentType in MAEC Package, for capturing the names/types/IDs of observations that may be made in comments. Closes #21.
